### PR TITLE
Endpoint fix

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@decsys/iaa",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@decsys/iaa",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decsys/iaa",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "For applying the type-1 Interval Agreement Approach",
   "module": "dist/decsys.iaa.esm.js",
   "files": [

--- a/js/src/iaa.test.js
+++ b/js/src/iaa.test.js
@@ -13,10 +13,7 @@ test("matches `main.py`", () => {
 });
 
 test("works with floats at both extremes", () => {
-  const intervals = [
-    [29, 51.067613404],
-    [20.640571195, 40]
-  ];
+  const intervals = [[29, 51.067613404], [20.640571195, 40]];
 
   const fs = new IntervalAgreementApproach();
   for (const d of intervals) fs.addInterval(d);
@@ -34,5 +31,15 @@ test("works with values exclusively outside the range 0 - 10", () => {
   expect(fs.membership(1)).toEqual(0);
   expect(fs.membership(62)).toEqual(0.75);
   expect(fs.membership(42)).toEqual(0.25);
+  expect(parseFloat(fs.centroid)).not.toBeNaN();
+});
+
+test("works with endpoint only values", () => {
+  const intervals = [[0, 100], [0, 0], [100, 100]];
+
+  const fs = new IntervalAgreementApproach();
+  for (const d of intervals) fs.addInterval(d);
+
+  expect(fs.membership(1)).not.toBeNaN();
   expect(parseFloat(fs.centroid)).not.toBeNaN();
 });

--- a/js/src/interval-map.js
+++ b/js/src/interval-map.js
@@ -38,7 +38,7 @@ class IntervalMap {
   set(key, value) {
     if (!(key instanceof Array) || key.length !== 2)
       throw new TypeError("The key must be an Array with 2 elements.");
-    if (key.some(x => !parseFloat(x)))
+    if (key.some(x => isNaN(parseFloat(x))))
       throw new TypeError("Both end points must be numbers.");
     this._map.set(key, value);
   }


### PR DESCRIPTION
interval sets including the value `0` failed the number check, because `0` is falsey.

`isNaN` is now used.